### PR TITLE
Add CI and maintenance automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /server
+    schedule: { interval: daily }
+  - package-ecosystem: npm
+    directory: /client-web
+    schedule: { interval: daily }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ghostcomms
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s --health-timeout=5s --health-retries=20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ghostcomms
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Server deps + prisma
+        working-directory: server
+        run: |
+          npm ci
+          npx prisma generate
+          npx prisma db push
+          npx tsc --noEmit
+      - name: Client build
+        working-directory: client-web
+        run: |
+          npm ci
+          npm run build

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -1,0 +1,21 @@
+name: Nightly Maintenance
+on:
+  schedule: [{ cron: "0 2 * * *" }]  # 02:00 UTC nightly
+  workflow_dispatch:
+jobs:
+  prune-expired:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }} # set this secret to your CH Postgres URL
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Install Prisma CLI
+        run: npm -g i prisma@5
+      - name: Prune envelopes
+        run: |
+          npx prisma db execute --file - <<'SQL'
+          DELETE FROM "Envelope" WHERE "expiresAt" < NOW();
+          VACUUM;
+          SQL


### PR DESCRIPTION
## Summary
- add CI workflow that builds server and client
- add nightly maintenance job to prune expired envelopes
- configure Dependabot for daily server/client dependency checks

## Testing
- `npm --prefix server run build`
- `npm --prefix client-web run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdb4e359c832dbaa017a854cce49f